### PR TITLE
[osx] - make OpenGL a required dependency which has to be found by cm…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,14 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(kodi REQUIRED)
+find_package(OpenGL REQUIRED)
 
 include_directories(${KODI_INCLUDE_DIR})
 
 set(PINGPONG_SOURCES src/main.cpp
                      src/pingpong.cpp)
 
-set(DEPLIBS)
+set(DEPLIBS ${OPENGL_LIBRARIES})
 
 build_addon(screensaver.pingpong PINGPONG DEPLIBS)
 

--- a/src/pingpong.cpp
+++ b/src/pingpong.cpp
@@ -24,7 +24,12 @@
 #include "main.h"
 #include "pingpong.h"
 
+#if defined(__APPLE__)
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
+
 #include <vector>
 
 #define NUMQUADS	3


### PR DESCRIPTION
…ake and include the right gl.h on darwin.

Also i noticed that the addon was not installed into the addons dir in my build tree as it is done usually @Montellese infoping ... 