### PR TITLE
Rename find-package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(OpenGL REQUIRED)
 
 include_directories(${KODI_INCLUDE_DIR})

--- a/screensaver.pingpong/addon.xml.in
+++ b/screensaver.pingpong/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.pingpong"
-  version="1.0.0"
+  version="1.1.0"
   name="Ping Pong"
   provider-name="spiff">
   <requires>


### PR DESCRIPTION
Package renaming is need after https://github.com/xbmc/xbmc/pull/9750 goes in.
The rest is to bring xml files up to par.