### PR TITLE
[win32] OpenGL isn't required for windows build. fix fixes build for …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(OpenGL REQUIRED)
+if(NOT CORE_SYSTEM_NAME MATCHES windows)
+  find_package(OpenGL REQUIRED)
+endif()
 
 include_directories(${KODI_INCLUDE_DIR}/..) # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
 
@@ -19,7 +21,9 @@ set(PINGPONG_HEADERS src/main.h
                      src/timer.h
                      src/types.h)
 
-set(DEPLIBS ${OPENGL_LIBRARIES})
+if(NOT CORE_SYSTEM_NAME MATCHES windows)
+  set(DEPLIBS ${OPENGL_LIBRARIES})
+endif()
 
 build_addon(screensaver.pingpong PINGPONG DEPLIBS)
 

--- a/src/pingpong.cpp
+++ b/src/pingpong.cpp
@@ -26,7 +26,7 @@
 
 #if defined(__APPLE__)
 #include <OpenGL/gl.h>
-#else
+#else !defined(WIN32)
 #include <GL/gl.h>
 #endif
 


### PR DESCRIPTION
…arm-uwp

let's wait what appveyor says